### PR TITLE
Add split action bar

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -13,7 +13,8 @@
     <application
         android:name=".CounterApplication"
         android:icon="@drawable/ic_launcher"
-        android:label="@string/app_name">
+        android:label="@string/app_name"
+        android:uiOptions="splitActionBarWhenNarrow">
         <activity
             android:name=".ui.CounterActivity"
             android:label="@string/app_name"


### PR DESCRIPTION
on small screens the counter name is not fully visible(if its more than a few letters) in portrait. 
this fixes that. tested on android 4.1.2
