### PR TITLE
added jcenter to repo list

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         mavenCentral()
+		jcenter()
     }
     dependencies {
         classpath "com.android.tools.build:gradle:2.2.2"
@@ -11,6 +12,7 @@ apply plugin: "com.android.application"
 
 repositories {
     mavenCentral()
+	jcenter()
 }
 
 dependencies {


### PR DESCRIPTION
[com.android.tools.build:gradle has moved from maven to jcenter since 2.0.](http://stackoverflow.com/questions/34157716/android-studio-could-not-find-com-android-tools-buildgradle2-0-0-alpha2#34179425)