### PR TITLE
counter's colour on landscape

### DIFF
--- a/src/main/res/layout-land/counter.xml
+++ b/src/main/res/layout-land/counter.xml
@@ -16,6 +16,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
+            android:textColor="?valueColor"
             android:textAppearance="@style/counter_value" />
     </FrameLayout>
 

--- a/src/main/res/layout-xlarge-land/counter.xml
+++ b/src/main/res/layout-xlarge-land/counter.xml
@@ -32,6 +32,7 @@
         android:layout_height="wrap_content"
         android:layout_centerHorizontal="true"
         android:layout_centerVertical="true"
+        android:textColor="?valueColor"
         android:textAppearance="@style/counter_value" />
 
 </RelativeLayout>


### PR DESCRIPTION
The colour of the counter is now the same on landscape and portrait.
The colour is retrieved from the styles.

Solves [https://github.com/gentlecat/counter/issues/43](url)